### PR TITLE
Add SRTP/DTLS-SRTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ This table lists IETF Security Area protocols with "no action needed", typically
 | SCEP     | <https://datatracker.ietf.org/doc/rfc8894/>   | LAMPS (?)      | CMS (RFC 5652), PKCS #10 (RFC 2986) |  |
 | S/MIME   | <https://datatracker.ietf.org/doc/rfc5751/>   | LAMPS        | CMS (RFC 5652)               | Section 4.1 explicitly lists RSA, DSA, SHA-1. So maybe this needs an update to only modern non-PQC crypto. |
 
+# Other Security protocols with no PQC-specific action needed
+This table lists IETF Security protocols with "no action needed", typically because that protocol does not itself specify any cryptographic algorithms but instead embeds other IETF cryptographic protocols. Therefore no action is needed for that protocol because it will inherit PQC as soon as its cryptographic dependencies support it. 
+
+| Protocol | RFC       | Working Group  | Cryptographic dependencies | Comment |
+|--------- |---------- |--------------- |--------------------------- |-------- |
+| SRTP     | <https://datatracker.ietf.org/doc/rfc3711/> | AVT | DTLS (RFC 9147) | KEX handled by DTLS (RFC 5763/5764), Symmetric key AEAD (AES-GCM) algos available for actual SRTP (RFC 7714) |
 
 # Suggestions for possible additions
 


### PR DESCRIPTION
Added a section for IETF security protocols that are outside of the Security Area.
Specifically I wanted to cite the Secure Real Time Protocol (SRTP) and its usage/dependency on DTLS.
Both should be okay...
DTLS-SRTP inheriting whatever DTLS implements for PQC KEX and SRTP itself having strong AEAD symmetric algos using AES-128/256 (deemed safe by [PQC for Engineers](https://datatracker.ietf.org/doc/html/draft-ar-pquip-pqc-engineers-02#name-symmetric-cryptography))